### PR TITLE
Fix typo in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Bintracker is an advanced, cross-platform chiptune music editor that supports many different sound routines on a wide range of 8-bit and 16-bit platforms. It is also a live programming environment running on top of [Chicken Scheme](https://call-cc.org/).
 
-At a basic level, Bintracker looks and feels like a [music tracker](https://en.wikipedia.org/wiki/Tracker_(music_software)), and can perfectly well be used as such. However, it also incorporates a range of features normally found in [digitial audio workstations](https://en.wikipedia.org/wiki/Digital_audio_workstation) and [audio programming languages](https://en.wikipedia.org/wiki/Audio_programming_language).
+At a basic level, Bintracker looks and feels like a [music tracker](https://en.wikipedia.org/wiki/Tracker_(music_software)), and can perfectly well be used as such. However, it also incorporates a range of features normally found in [digital audio workstations](https://en.wikipedia.org/wiki/Digital_audio_workstation) and [audio programming languages](https://en.wikipedia.org/wiki/Audio_programming_language).
 
 Both the editor itself, as well as the range of supported chiptune drivers and target platforms can be easily extended through plugins.
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -2,7 +2,7 @@
 
 Bintracker is an open source, cross-platform chiptune music editor that supports many different chiptune drivers on a wide range of target platforms.
 
-At a basic level, Bintracker looks and feels like a [music tracker](https://en.wikipedia.org/wiki/Tracker_(music_software)), and can perfectly well be used as such. However, it also incorporates a range of features normally found in [digitial audio workstations](https://en.wikipedia.org/wiki/Digital_audio_workstation) and [audio programming languages](https://en.wikipedia.org/wiki/Audio_programming_language).
+At a basic level, Bintracker looks and feels like a [music tracker](https://en.wikipedia.org/wiki/Tracker_(music_software)), and can perfectly well be used as such. However, it also incorporates a range of features normally found in [digital audio workstations](https://en.wikipedia.org/wiki/Digital_audio_workstation) and [audio programming languages](https://en.wikipedia.org/wiki/Audio_programming_language).
 
 Both the editor itself, as well as the range of supported chiptune drivers and target platforms can be easily extended.
 

--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -59,7 +59,7 @@ When plugins are loaded, all their bindings are imported into the global namespa
 
 This will only make `myplug::foo` available in the global namespace, without leaking `internal-proc`.
 
-For anything more comlex, a better approach is to put the actual implementation in a separate file, wrapping the plugin code in a [Chicken module](https://wiki.call-cc.org/man/5/Modules). The above example, rewritten using this approach would look something like this:
+For anything more complex, a better approach is to put the actual implementation in a separate file, wrapping the plugin code in a [Chicken module](https://wiki.call-cc.org/man/5/Modules). The above example, rewritten using this approach would look something like this:
 
 ```Scheme
 ;; file plugins/myplug/myplug-impl.scm

--- a/libmdal/docs/MMOD_SPECIFICATION.md
+++ b/libmdal/docs/MMOD_SPECIFICATION.md
@@ -198,7 +198,7 @@ The following example assumes an underlying MDAL engine definition that specifie
 
 Notable changes from Version 1 include:
 
-- Name change: MDMOD -> MMDO
+- Name change: MDMOD -> MMOD
 - The custom syntax is replaced by Symbolic Expressions.
 - Node instances are addressed through numerical identifiers instead of named strings.
 - Automatic scope resolution is dropped, and replaced by explicit Assignments.


### PR DESCRIPTION
I found a pile of typos while reading the docs. I don't think I'll be reading any further. I'm kinda bored, and I don't have the program running for me to poke at.

## Unresolved questions

- https://bintracker.org/documentation/MMOD_SPECIFICATION.html#changes-from-version-1 Did you mean MMOD and not MMDO?